### PR TITLE
Add name to layout.conf

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,1 +1,2 @@
+name = telred
 masters = gentoo


### PR DESCRIPTION
Shuts up the `WARNING: One or more repositories have missing repo_name entries` messages