### PR TITLE
net-im/sky: fix qtgui dependency

### DIFF
--- a/net-im/sky/sky-2.1.7520.1.ebuild
+++ b/net-im/sky/sky-2.1.7520.1.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	!net-im/sky-ng
 	dev-db/sqlite:3
 	>=dev-qt/qtcore-5.6:5
-	>=dev-qt/qtgui-5.6:5[dbus,gif,jpeg,png,xcb]
+	|| ( >=dev-qt/qtgui-5.6:5[dbus,gif,jpeg,png,xcb] >=dev-qt/qtgui-5.14:5[dbus,gif,jpeg,png] )
 	>=dev-qt/qtnetwork-5.6:5
 	>=dev-qt/qtwidgets-5.6:5
 	!legacy-openssl? ( dev-libs/openssl:0/1.1 )


### PR DESCRIPTION
qtgui-5.14 doesn't have an `xsb` use flag anymore, thus remove it.